### PR TITLE
fmt, tab support, fix paths, cmd validation

### DIFF
--- a/src/cmd_validation.ts
+++ b/src/cmd_validation.ts
@@ -1,6 +1,6 @@
-export type Cmd = "pwd" | "cd" | "mkdir" | "ls" | "touch" | "cat" | "echo";
+export type Cmd = (typeof cmds)[number];
 
-const cmds: Cmd[] = [
+const cmds = [
     "pwd",
     "cd",
     "mkdir",
@@ -8,7 +8,7 @@ const cmds: Cmd[] = [
     "touch",
     "cat",
     "echo",
-];
+] as const;
 
 export function validCmds(): string[] {
     return cmds.map((v) => v.toString());

--- a/src/cmd_validation.ts
+++ b/src/cmd_validation.ts
@@ -1,0 +1,19 @@
+export type Cmd = "pwd" | "cd" | "mkdir" | "ls" | "touch" | "cat" | "echo";
+
+const cmds: Cmd[] = [
+    "pwd",
+    "cd",
+    "mkdir",
+    "ls",
+    "touch",
+    "cat",
+    "echo",
+];
+
+export function validCmds(): string[] {
+    return cmds.map((v) => v.toString());
+}
+
+export function rawCmdIsCmd(rawCmd: string): rawCmd is Cmd {
+    return cmds.map((v) => v.toString()).includes(rawCmd);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import { rawCmdIsCmd, validCmds } from "./cmd_validation.ts";
 import { fileChildren, Session } from "./file_system.ts";
 import { Dir, dirChildren, reverseOrphanDirTree } from "./file_system.ts";
 import { CommandLexer } from "./lexer.ts";
@@ -21,12 +22,101 @@ input.addEventListener("blur", hideCursor);
 addEventListener("resize", setInputMaxLength);
 addEventListener("click", () => input.focus());
 
+function autoCompleteMatches(
+    input: string,
+    options: string[],
+): string[] {
+    const matches = options.map((v) => v).filter((v) => v.startsWith(input));
+    if (matches.length <= 1) {
+        return matches;
+    }
+    const maxLength = matches.map((v) => v.length)
+        .toSorted()
+        .toReversed()
+        .pop();
+    if (maxLength === undefined) {
+        throw new Error("unreachable: we return if length <= 1");
+    }
+    let closestLength = 0;
+    const letters = matches[0].split("").slice(0, maxLength);
+    for (let letterIdx = 0; letterIdx < maxLength; ++letterIdx) {
+        const letterToMatch = letters[letterIdx];
+        if (matches.every((match) => match[letterIdx] === letterToMatch)) {
+            // we add 1 here because it's a length, not an index
+            closestLength = letterIdx + 1;
+        } else {
+            break;
+        }
+    }
+    if (closestLength === input.length) {
+        return matches;
+    } else if (closestLength < input.length) {
+        throw new Error(
+            "unreachable: matches that start with {input} all share {input} in common",
+        );
+    }
+    return [matches[0].substring(0, closestLength)];
+}
+
+function requestAutoComplete(cmd: string, last: string | undefined): string[] {
+    if (last === undefined) {
+        if (rawCmdIsCmd(cmd)) {
+            return [];
+        }
+        return autoCompleteMatches(cmd, validCmds());
+    } else if (!rawCmdIsCmd(cmd)) {
+        return [];
+    }
+    switch (cmd) {
+        case "cd":
+        case "mkdir":
+        case "ls":
+        case "touch":
+        case "cat": {
+            const fileSeperator = last.lastIndexOf("/");
+            const path = fileSeperator !== -1
+                ? last.substring(0, fileSeperator + 1)
+                : undefined;
+            const filename = fileSeperator !== -1
+                ? last.substring(fileSeperator + 1)
+                : last;
+            const files = session.listFiles(path);
+            if (!files.ok) {
+                return [];
+            }
+            const result = autoCompleteMatches(
+                filename,
+                files.value,
+            );
+            return result.map((v) => path !== undefined ? path + v : v);
+        }
+        case "pwd":
+        case "echo": {
+            return [];
+        }
+    }
+}
+
 input.addEventListener("keydown", function (event: KeyboardEvent) {
     if (event.key === "Enter") {
         addHistoryItem(runCommand(input.value));
+        input.value = "";
         updatePromptAndInput();
     } else if (event.ctrlKey && event.key === "c") {
         addHistoryItem("");
+        input.value = "";
+    } else if (event.key === "Tab") {
+        const [cmd, ...args] = input.value.trimStart().split(/\s+/g);
+        const last = args.pop();
+        const options = requestAutoComplete(cmd, last);
+        if (options.length === 1) {
+            const option = options[0];
+            const idx = input.value.lastIndexOf(last ?? cmd);
+            input.value = input.value.substring(0, idx) + option;
+        } else if (options.length > 1) {
+            addHistoryItem(options.join("\n"));
+        }
+        event.preventDefault();
     } else if (event.key === "ArrowUp") {
         if (commandHistoryIndex >= commandHistory.length) {
             return;
@@ -99,7 +189,7 @@ session.cd(`/home/${username}`);
 addHistoryItem(runCommand("cat welcome.txt"));
 
 function runCommand(command: string): string {
-    const args = command.trim().split(" ");
+    const [cmd, ...args] = command.trim().split(" ");
     const lexer = new CommandLexer(command);
     while (!lexer.done()) {
         const result = lexer.next();
@@ -110,17 +200,21 @@ function runCommand(command: string): string {
         }
     }
 
-    switch (args[0]) {
-        case "":
-            return "";
+    if (cmd === "") {
+        return "";
+    }
+    if (!rawCmdIsCmd(cmd)) {
+        return `${cmd}: Command not found`;
+    }
+    switch (cmd) {
         case "pwd":
             return session.cwd();
         case "cd": {
-            if (args.length > 2) {
+            if (args.length > 1) {
                 return "cd: too many arguments";
             }
 
-            const res = session.cd(args[1]);
+            const res = session.cd(args[0]);
             if (!res.ok) {
                 return `cd: ${res.error}`;
             }
@@ -128,11 +222,11 @@ function runCommand(command: string): string {
             return "";
         }
         case "mkdir": {
-            if (args.length === 1) {
+            if (args.length === 0) {
                 return "mkdir: missing operand";
             }
 
-            for (const dir of args.slice(1)) {
+            for (const dir of args) {
                 const res = session.mkdir(dir);
                 if (!res.ok) {
                     return `mkdir: ${res.error}`;
@@ -142,48 +236,46 @@ function runCommand(command: string): string {
             return "";
         }
         case "ls": {
-            if (args.length === 1) {
+            if (args.length === 0) {
                 const res = session.listFiles();
                 if (!res.ok) {
                     return res.error;
                 }
-                return res.value;
+                return res.value.join("\n");
             }
-            return args.slice(1)
+            return args
                 .map((arg) => {
                     const res = session.listFiles(arg);
                     if (!res.ok) {
                         return res.error;
                     }
-                    return res.value;
+                    return res.value.join("\n");
                 }).join("\n");
         }
         case "touch": {
-            if (args.length === 1) {
+            if (args.length === 0) {
                 return "touch: missing file operand";
             }
-            for (const fn of args.slice(1)) {
+            for (const fn of args) {
                 session.touch(fn);
             }
             return "";
         }
         case "cat": {
-            if (args.length === 1) {
+            if (args.length === 0) {
                 return "cat: missing file operand";
             }
-            return args.slice(1).map((v) => {
+            return args.map((v) => {
                 const r = session.cat(v);
                 return r.ok ? r.value : r.error;
             }).reduce((acc, v) => acc + "\n" + v);
         }
         case "echo": {
-            if (args.length === 1) {
+            if (args.length === 0) {
                 return "\n";
             }
-            return args[1];
+            return args[0];
         }
-        default:
-            return `${args[0]}: Command not found`;
     }
 }
 
@@ -211,8 +303,6 @@ function addHistoryItem(output: string) {
     history.appendChild(historyItem);
 
     commandHistory.push(input.value);
-
-    input.value = "";
 }
 
 function setInputMaxLength() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@ import { Dir, dirChildren, reverseOrphanDirTree } from "./file_system.ts";
 import { CommandLexer } from "./lexer.ts";
 import "./style.css";
 
-
 const input = document.querySelector<HTMLInputElement>("#terminal-input")!;
 const cursor = document.querySelector<HTMLSpanElement>("#cursor")!;
 const history = document.querySelector<HTMLDivElement>("#history")!;
@@ -19,8 +18,8 @@ input.addEventListener("keydown", updatePromptAndInput);
 input.addEventListener("keyup", updatePromptAndInput);
 input.addEventListener("focus", showCursor);
 input.addEventListener("blur", hideCursor);
-window.addEventListener("resize", setInputMaxLength);
-window.addEventListener("click", () => input.focus());
+addEventListener("resize", setInputMaxLength);
+addEventListener("click", () => input.focus());
 
 input.addEventListener("keydown", function (event: KeyboardEvent) {
     if (event.key === "Enter") {
@@ -29,12 +28,14 @@ input.addEventListener("keydown", function (event: KeyboardEvent) {
     } else if (event.ctrlKey && event.key === "c") {
         addHistoryItem("");
     } else if (event.key === "ArrowUp") {
-        if (commandHistoryIndex >= commandHistory.length)
+        if (commandHistoryIndex >= commandHistory.length) {
             return;
+        }
 
         commandHistoryIndex++;
 
-        input.value = commandHistory[commandHistory.length - commandHistoryIndex];
+        input.value =
+            commandHistory[commandHistory.length - commandHistoryIndex];
         updateCursorPos(input.value.length);
 
         event.preventDefault();
@@ -53,7 +54,8 @@ input.addEventListener("keydown", function (event: KeyboardEvent) {
 
         commandHistoryIndex--;
 
-        input.value = commandHistory[commandHistory.length - commandHistoryIndex];
+        input.value =
+            commandHistory[commandHistory.length - commandHistoryIndex];
         updateCursorPos(input.value.length);
 
         event.preventDefault();
@@ -62,9 +64,8 @@ input.addEventListener("keydown", function (event: KeyboardEvent) {
 
 async function loadTextFile(path: string): Promise<string> {
     const response = await fetch(path);
-    return await response.text()
+    return await response.text();
 }
-
 
 function updateCursorPos(pos: number) {
     input.setSelectionRange(pos, pos);
@@ -80,7 +81,9 @@ const root: Dir = {
                 [username]: {
                     name: username,
                     dirs: dirChildren({}),
-                    files: fileChildren({"welcome.txt": await loadTextFile("welcome.txt")}),
+                    files: fileChildren({
+                        "welcome.txt": await loadTextFile("welcome.txt"),
+                    }),
                 },
             }),
             files: new Map(),
@@ -95,23 +98,21 @@ const session = new Session(root, username);
 session.cd(`/home/${username}`);
 addHistoryItem(runCommand("cat welcome.txt"));
 
-
-
 function runCommand(command: string): string {
     const args = command.trim().split(" ");
-    const lexer = new CommandLexer(command)
+    const lexer = new CommandLexer(command);
     while (!lexer.done()) {
-        const result = lexer.next()
+        const result = lexer.next();
         if (!result.ok) {
-            console.error(result.error)
+            console.error(result.error);
         } else {
-            console.log(result.value)
+            console.log(result.value);
         }
     }
 
     switch (args[0]) {
-		case "":
-			return "";
+        case "":
+            return "";
         case "pwd":
             return session.cwd();
         case "cd": {
@@ -157,25 +158,28 @@ function runCommand(command: string): string {
                     return res.value;
                 }).join("\n");
         }
-		case "touch": {
-			if (args.length === 1) {
-				return "touch: missing file operand"
-			}
-			for (const fn of args.slice(1)) {
-				session.touch(fn);
-			}
-			return ""
-		}
-		case "cat": {
-			if (args.length === 1) {
-				return "cat: missing file operand"
-			}
-			return args.slice(1).map(v => {const r = session.cat(v); return r.ok ? r.value : r.error }).reduce((acc, v) => acc + "\n" + v);
-		}
+        case "touch": {
+            if (args.length === 1) {
+                return "touch: missing file operand";
+            }
+            for (const fn of args.slice(1)) {
+                session.touch(fn);
+            }
+            return "";
+        }
+        case "cat": {
+            if (args.length === 1) {
+                return "cat: missing file operand";
+            }
+            return args.slice(1).map((v) => {
+                const r = session.cat(v);
+                return r.ok ? r.value : r.error;
+            }).reduce((acc, v) => acc + "\n" + v);
+        }
         case "echo": {
             if (args.length === 1) {
-				return "\n";
-			}
+                return "\n";
+            }
             return args[1];
         }
         default:

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,7 +84,7 @@
 
 "@esbuild/linux-x64@0.21.5":
   version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz#6d8f0c768e070e64309af8004bb94e68ab2bb3b0"
+  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz"
   integrity sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
 
 "@esbuild/netbsd-x64@0.21.5":
@@ -174,7 +174,7 @@
 
 "@rollup/rollup-linux-x64-gnu@4.21.2":
   version "4.21.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.2.tgz#0dadf34be9199fcdda44b5985a086326344f30ad"
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.2.tgz"
   integrity sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==
 
 "@rollup/rollup-linux-x64-musl@4.21.2":
@@ -199,12 +199,12 @@
 
 "@types/estree@1.0.5":
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
+  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
 esbuild@^0.21.3:
   version "0.21.5"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.21.5.tgz#9ca301b120922959b766360d8ac830da0d02997d"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz"
   integrity sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
   optionalDependencies:
     "@esbuild/aix-ppc64" "0.21.5"
@@ -238,17 +238,17 @@ fsevents@~2.3.2, fsevents@~2.3.3:
 
 nanoid@^3.3.7:
   version "3.3.7"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
 picocolors@^1.0.1:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.0.tgz#5358b76a78cde483ba5cef6a9dc9671440b27d59"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz"
   integrity sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==
 
 postcss@^8.4.43:
   version "8.4.45"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.45.tgz#538d13d89a16ef71edbf75d895284ae06b79e603"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.45.tgz"
   integrity sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==
   dependencies:
     nanoid "^3.3.7"
@@ -257,7 +257,7 @@ postcss@^8.4.43:
 
 rollup@^4.20.0:
   version "4.21.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.21.2.tgz#f41f277a448d6264e923dd1ea179f0a926aaf9b7"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-4.21.2.tgz"
   integrity sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==
   dependencies:
     "@types/estree" "1.0.5"
@@ -282,17 +282,17 @@ rollup@^4.20.0:
 
 source-map-js@^1.2.0:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
 typescript@^5.5.3:
   version "5.5.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz"
   integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 vite@^5.4.3:
   version "5.4.3"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.3.tgz#771c470e808cb6732f204e1ee96c2ed65b97a0eb"
+  resolved "https://registry.npmjs.org/vite/-/vite-5.4.3.tgz"
   integrity sha512-IH+nl64eq9lJjFqU+/yrRnrHPVTlgy42/+IzbOdaFDVlyLgI/wDlf+FCobXLX1cT0X5+7LMyH1mIy2xJdLfo8Q==
   dependencies:
     esbuild "^0.21.3"


### PR DESCRIPTION
## fmt:

- my formatter (deno fmt) autoformatted some stuff. oops.

## tab support:

- press tab to prompt a list of options
  - if no command is given, it will attempt to autocomplete to a list of commands
  - for commands that work with files (cat, ls, mkdir, etc.), it will autocomplete to a list of files. 
- if autocompleting files, and the input ends with a `/`, it will instead autocomplete on the directory at that path's children
- it autocompletes to the closest match, which is either:
  - a full match (i.e. `input="a", options=["a_v", "b_v", "c_v"], result="a_v"`) 
  - or the closest match possible (i.e., `input="a", options=["a_a", "a_b", "a_c"], result="a_"`)
 
## fix paths:

- while implementing, i discovered a bug in the `Session` class in which `/` is not actually supported, so the command `mkdir a/b` would literally create a directory called `a/b` on the current directory instead of creating a directory `a` with a child `b` - as a consequence, my tab support was bugged. i have rectified this, so now i.e. `mkdir a/b/c` will find directory a's child b, and then add a child c to it. i have implemented this for the other commands aswell

## cmd validation:

- while implementing, i required a list of commands. i did not like the idea of just having a list of commands ["cd", "cat"] etc. that was not type checked, which means nothing's stopping you from implementing a new command, "abc", and not implementing autocompletions, nor implementing an invalid command, like i.e. "cats" (with a typo). i have rectified this by adding a type Cmd, a way to get the list of valid commands (used for autocompletions), and a way to typecheck raw command input. i have also done a few refactors in the args[0], args[1] space just because i saw fit.