### PR TITLE
add clear command

### DIFF
--- a/src/cmd_validation.ts
+++ b/src/cmd_validation.ts
@@ -8,6 +8,7 @@ const cmds = [
     "touch",
     "cat",
     "echo",
+    "clear",
 ] as const;
 
 export function validCmds(): string[] {


### PR DESCRIPTION
currently, callers of `runCommand` assumes the latter will return the output as text. in all cases the caller will pass the result directly into `addHistoryItem`. this functionality has remained unchanged. i've added some "meta command" that are optionally passed to `runCommand`. this includes a clear-callback, so that the caller of `runCommand` can optionally support the clear-command.