### PR TITLE
rewrite node pathing, fix empty cmds, fix janky cwd and lines

### DIFF
--- a/src/initial_fs.ts
+++ b/src/initial_fs.ts
@@ -1,37 +1,29 @@
-import {
-    Dir,
-    dirChildren,
-    fetchFile,
-    fileChildren,
-    linkDirTreeOrphans,
-} from "./file_system.ts";
+import { fetchFile, initialChildren, InitialRootDir } from "./file_system.ts";
 
-export async function root(username: string): Promise<Dir> {
+export async function root(username: string): Promise<InitialRootDir> {
     const motd = "motd.txt";
-    const root: Dir = {
-        tag: "dir",
-        name: "/",
-        parent: null,
-        children: dirChildren({
+    const root: InitialRootDir = {
+        tag: "root_dir",
+        children: initialChildren({
             "home": {
                 tag: "dir",
                 name: "home",
-                parent: null,
-                children: dirChildren({
+                children: initialChildren({
                     [username]: {
                         tag: "dir",
                         name: username,
-                        parent: null,
-                        children: fileChildren({
-                            [motd]: await fetchFile(motd),
+                        children: initialChildren({
+                            [motd]: {
+                                tag: "file",
+                                name: motd,
+                                content: await fetchFile(motd),
+                            },
                         }),
                     },
                 }),
             },
         }),
     };
-
-    linkDirTreeOrphans(root, null);
 
     return root;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -442,7 +442,7 @@ async function main() {
     session.cd(`/home/${username}`);
 
     const ui = new Ui({
-        updatePrompt: (update) => update(session.cwdString()),
+        updatePrompt: (update) => update(session.formattedCwd()),
         keyListener: async (event) =>
             ui.executeActions(await uiKeyEvent(session, event)),
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -187,7 +187,7 @@ async function uiKeyEvent(
         if (output.redirects.length === 0) {
             actions.push({
                 tag: "add_history_item",
-                "output": res.value.content,
+                output: res.value.content,
             });
         } else {
             for (const redirect of output.redirects) {
@@ -223,6 +223,7 @@ async function uiKeyEvent(
             actions.push({ tag: "clear_history" });
         }
 
+        actions.push({ tag: "set_cwd", cwd: session.formattedCwd() });
         actions.push({ tag: "clear_input" });
         return actions;
     }
@@ -442,7 +443,6 @@ async function main() {
     session.cd(`/home/${username}`);
 
     const ui = new Ui({
-        updatePrompt: (update) => update(session.formattedCwd()),
         keyListener: async (event) =>
             ui.executeActions(await uiKeyEvent(session, event)),
     });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -45,14 +45,19 @@ export class CommandParser {
             short_options: [],
             arguments: [],
         };
-        const binRes = this.eatArgument();
+        const binRes = this.lexer.next();
         if (!binRes.ok) {
             return binRes;
         }
-        if (binRes.value === null) {
+        const binToken = binRes.value;
+        if (binToken === null) {
             return Ok(cmd);
+        } else if (binToken.value.tag !== "argument") {
+            return Err(
+                `expected argument at ${binToken.index}, got '${binToken.value.tag}'`,
+            );
         }
-        cmd.bin = binRes.value.argument;
+        cmd.bin = binToken.value.argument;
         while (true) {
             const tokenRes = this.lexer.next();
             if (!tokenRes.ok) {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -12,7 +12,6 @@ export type KeyEvent = {
     preventDefault: () => void;
 };
 
-export type UpdatePromptFunctor = (functor: (cwd: string) => void) => void;
 export type KeyEventFunctor = (event: KeyEvent) => void;
 
 export type UiConfig = {


### PR DESCRIPTION
## rewrite node pathing

rewrote the node pathing system so it now works based off of absolute paths at all times. as a side effect, this also fixes `.` and `..` operators not working as expected.

it works by first resolving the maybe relative path (`~`, `/`, ` `) to an absolute one, and then filtering away any `.` and chewing through the segments to apply any `..` it finds. it now has a resolved absolute path that it can find nodes with.

i also converted the root node as it's own special thing instead of just being a node named "/", this makes sense because it is not actually just a node named "/", it doesn't have a name or parent, and should be handled specially. 

as a side effect, that means if i know i have a dir or file, i know it's not the root node, instead of checking whether a dir's parent is null. it also means it's impossible to create a dir without a parent, reducing possible mistakes.

this means i can handle paths as a list of absolute segments (i.e. `/home/guest/motd.txt`, `~/motd.txt`, `../guest/motd.txt`, `motd.txt` will all be resolved to `[home, guest, motd.txt]`) and then i can simply climb up from the root node, which is much easier

i also rewrote the linking stage of nodes, so you now give the session a `InitialRootDir` with some `InitialDir | InitialFile` children, and it goes through and links the parents, converting them to a `RootDir` and `Dir | File` with the appropriate `parent` value

i also gave files parents, just to make the `rm` command a little bit cleaner

## rewrote fs error formatting

errors are now made with the `formatIoError(path: string, error: IoError): string` function, which ensures consistent error formatting. i.e. some had `"${path}": ${error}`, some had `${path}: ${error}`, some had `'${path}': ${error}`, and different ways of spelling writing things etc.

## fix empty cmds

fixed the parser showing a lexing error when the command was empty

## fix janky cwd

instead of letting the user of the `Ui` instance update the cwd whenever, i converted updating cwd into its own action, so it can be handled synchronously just like all the other actions. as a side effect it has been refactored into its own function instead of being updated when the user is typing, which is one less direct dependency on `file_system.Session`.

## fix janky lines

before, if you wrote i.e. `ls`, the "ls" would flash on your new input for a second before being cleared. i have resolved this by updating the prompt immediately after executing actions, and it seems to work