### PR TITLE
fix xdg-open, deduplicate backend code

### DIFF
--- a/backend.ts
+++ b/backend.ts
@@ -2,31 +2,28 @@ import { mime } from "https://deno.land/x/mimetypes@v1.0.0/mod.ts";
 import { serveDir } from "jsr:@std/http/file-server";
 import * as path from "jsr:@std/path";
 
-function base64ToBytes(base64: string): Uint8Array {
-    return new Uint8Array(atob(base64).split("").map((c) => c.charCodeAt(0)));
-}
-
-function responseFromFileAndData(
-    filename: string,
-    data: string,
-): Response {
-    const ext = path.extname(filename).substring(".".length);
+async function responseFromFile(
+    data: File,
+): Promise<Response> {
+    const ext = path.extname(data.name).substring(".".length);
     const filetype = mime.getType(ext) ?? "application/octet-stream";
-    const body = base64ToBytes(data);
-    return new Response(body, {
-        headers: new Headers({ "Content-Type": filetype }),
+    const headers = new Headers({
+        "Content-Type": filetype,
+        "Content-Disposition": `inline; filename="${data.name}"`,
     });
+    return await data.bytes().then((data) => new Response(data, { headers }));
 }
 
-export function serveXdgOpenRequest(req: Request): Response {
-    const url = new URL(req.url);
-    const params = url.searchParams;
-    const filename = params.get("filename");
-    const data = params.get("data");
-    if (filename === null || data === null) {
-        return new Response("invalid body: missing filename or data");
+export async function serveXdgOpenRequest(req: Request): Promise<Response> {
+    const body = await req.formData();
+    const data = body.get("data");
+    if (data === null) {
+        return new Response("invalid body: missing data");
     }
-    return responseFromFileAndData(filename, data);
+    if (!(data instanceof File)) {
+        return new Response("invalid body: data should be a file");
+    }
+    return await responseFromFile(data);
 }
 
 export async function serveWgetRequest(req: Request): Promise<Response> {
@@ -37,13 +34,13 @@ export async function serveWgetRequest(req: Request): Promise<Response> {
 }
 
 function main() {
-    Deno.serve({ port: 5823 }, (req: Request) => {
+    Deno.serve({ port: 5823 }, async (req: Request) => {
         const url = new URL(req.url);
         if (url.pathname.startsWith("/bin/xdg-open")) {
-            return serveXdgOpenRequest(req);
+            return await serveXdgOpenRequest(req);
         }
         if (url.pathname.startsWith("/bin/wget")) {
-            return serveWgetRequest(req);
+            return await serveWgetRequest(req);
         }
         return serveDir(req, {
             fsRoot: "dist",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,7 +1,8 @@
 {
     "tasks": {
         "bundle": "deno run --allow-read --allow-write --allow-env --allow-run bundle.ts",
-        "dev": "deno run --allow-net --allow-read --allow-write --allow-env --allow-run dev.ts"
+        "dev": "deno run --allow-net --allow-read --allow-write --allow-env --allow-run dev.ts",
+        "backend": "deno run --allow-net backend.ts"
     },
     "compilerOptions": {
         "checkJs": false,

--- a/dev.ts
+++ b/dev.ts
@@ -47,13 +47,13 @@ function serveDist(addr: Addr) {
         port: addr.port,
         hostname: addr.hostname,
         onListen: (_) => listening(addr),
-    }, (req: Request) => {
+    }, async (req: Request) => {
         const url = new URL(req.url);
         if (url.pathname.startsWith("/bin/xdg-open")) {
-            return serveXdgOpenRequest(req);
+            return await serveXdgOpenRequest(req);
         }
         if (url.pathname.startsWith("/bin/wget")) {
-            return serveWgetRequest(req);
+            return await serveWgetRequest(req);
         }
         return serveDir(req, {
             fsRoot: "dist",

--- a/dev.ts
+++ b/dev.ts
@@ -1,15 +1,6 @@
 import { serveDir } from "jsr:@std/http/file-server";
 import { bundle } from "./bundle.ts";
-import { serveWgetRequest, serveXdgOpenRequest } from "./backend.ts";
-
-function listening(addr: Addr) {
-    console.log(`Listening on http://${addr.hostname}:${addr.port}/`);
-}
-
-type Addr = {
-    hostname: string;
-    port: number;
-};
+import { Addr, listening, serveBinAndDist } from "./backend.ts";
 
 async function check() {
     const command = new Deno.Command("deno", {
@@ -42,27 +33,6 @@ async function watchAndBundle(addr: Addr) {
     }
 }
 
-function serveDist(addr: Addr) {
-    Deno.serve({
-        port: addr.port,
-        hostname: addr.hostname,
-        onListen: (_) => listening(addr),
-    }, async (req: Request) => {
-        const url = new URL(req.url);
-        if (url.pathname.startsWith("/bin/xdg-open")) {
-            return await serveXdgOpenRequest(req);
-        }
-        if (url.pathname.startsWith("/bin/wget")) {
-            return await serveWgetRequest(req);
-        }
-        return serveDir(req, {
-            fsRoot: "dist",
-            urlRoot: "",
-            quiet: true,
-        });
-    });
-}
-
 if (import.meta.main) {
     const addr = {
         hostname: "0.0.0.0",
@@ -70,5 +40,5 @@ if (import.meta.main) {
     };
     await bundle();
     watchAndBundle(addr);
-    serveDist(addr);
+    serveBinAndDist(addr);
 }

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -1,5 +1,5 @@
-export function stringToBytes(value: string): Uint8Array {
-    return new TextEncoder().encode(value);
+export function textToBytes(text: string): Uint8Array {
+    return new TextEncoder().encode(text);
 }
 
 export function concatBytes(...arrays: Uint8Array[]): Uint8Array {
@@ -19,9 +19,6 @@ export function concatBytes(...arrays: Uint8Array[]): Uint8Array {
     return result;
 }
 
-export function bytesToBase64(bytes: Uint8Array): string {
-    const binStr = Array
-        .from(bytes, (byte) => String.fromCodePoint(byte))
-        .join("");
-    return btoa(binStr);
+export function bytesToText(bytes: Uint8Array): string {
+    return new TextDecoder().decode(bytes);
 }


### PR DESCRIPTION
## deduplicate backend code

moved some code that dev.ts and backend.ts shared into backend.ts. `backend.ts`'s responsibility is to serve `dist/` and handle `/bin/` paths, and `dev.ts` is responsible for doing backend's work, and watching for changes and type-checking and re-building frontend code.

## fix xdg-open

this problem is dual faced:

1. before, file data for dynamic files was sent by base-64 encoding the data, and including it as a query parameter. this was done with the knowledge that some files are simply much too large and as such are longer than the URL length limit supported by most browsers and servers, but not having the energy to implement a better solution. 
this is now fixed, we instead build a form, include a `<input type="file">` with the file's information, and then submit and discard the form, creating a new window as a `POST` request instead of a standard `window.open`. this worked as expected

3. before, all data was handled as strings before being returned to `runCommand`, which also returned a `type Output = { ..., output: string }`. 
the problem arises when i.e. catting a binary file such as an image, and redirecting it to another file, the binary data would be decoded as a string, to (possibly) write to the history, and then encoded back into a uint8array to write to the file. 
this was not a lossless process, as it would decode unprintable characters as a generic "invalid character" square, which then when reencoded would obviously be an entirely different byte, corrupting the binary data in the process. 
i have rectified this by, in short, treating output and file content as a uint8array, and only encoding it into text when specifically required, i.e. when adding to output history. this solves the problem.
you can now `wget [image_url.jpg]`, `cat [image.jpg] > new_image.jpg` and `xdg-open new_image.jpg` without the file being corrupted. hurray !