### PR TITLE
revolt against 'display: flex', return to 'position: static' tradition

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,12 +16,12 @@
     <body>
         <div id="history"></div>
         <div id="input-wrapper">
-            <div id="user" class="user-prefix">
+            <span id="user" class="user-prefix">
                 <span class="user">guest@mtkonge</span>
                 <span>:</span>
                 <span id="dir" class="dir">~</span>
                 <span>$ </span>
-            </div>
+            </span>
             <input
                 id="terminal-input"
                 spellcheck="false"

--- a/public/style.css
+++ b/public/style.css
@@ -1,7 +1,4 @@
 * {
-    margin: 0;
-    font-size: 20px;
-    font-family: "Ubuntu Mono", monospace;
     -ms-overflow-style: none; /* IE and Edge */
     scrollbar-width: none; /* Firefox */
 }
@@ -10,85 +7,17 @@
     display: none;
 }
 
-span, .history-list {
-    white-space: pre; /*enable whitespace*/
-}
-
 body {
+    font-family: "Ubuntu Mono", monospace;
     background-color: #222228;
     color: #f5f5f5;
-}
-
-#input-wrapper {
-    display: flex;
-    font-size: 0;
-    margin-left: 8px;
-}
-
-.user-and-command {
-    display: flex;
-}
-
-#history {
-    display: flex;
-    flex-direction: column;
-    margin-left: 8px;
-}
-
-.history-item {
-    display: flex;
+    font-size: 1.25rem;
+    margin: 0 0.5rem;
+    word-break: break-all;
 }
 
 .user-prefix {
-    display: flex;
-}
-
-#input-wrapper #terminal-input {
-    padding: 0;
-    margin: 0;
-    width: 0;
-    height: 0;
-    border: none;
-    opacity: 0;
-}
-
-#input-wrapper #terminal-input-label {
-    position: relative;
-    text-decoration: none;
-    border: none;
-    background-color: transparent;
-    outline: none;
-    color: #f5f5f5;
-    caret-color: transparent;
-    width: 100%;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    padding: 0;
-}
-
-#input-wrapper #terminal-input-cursor {
-    left: 0;
-    position: absolute;
-}
-
-#input-wrapper #terminal-input-cursor-padding {
-    opacity: 0;
-}
-
-#input-wrapper #terminal-input-cursor-selection {
-    font-weight: bold;
-    animation: blink 1s step-start infinite;
-}
-
-#input-wrapper #terminal-input-cursor-selection.block {
-    font-weight: normal;
-    background-color: #f5f5f5;
-    color: #222228;
-}
-
-#input-wrapper input:not(:focus) + label #terminal-input-cursor {
-    display: none;
+    white-space: pre;
 }
 
 .user {
@@ -97,6 +26,38 @@ body {
 
 .dir {
     color: #4488ff;
+}
+
+.history-list {
+    white-space: pre-wrap;
+}
+
+#input-wrapper {
+    position: relative;
+}
+
+#terminal-input {
+    padding: 0;
+    margin: 0;
+    width: 0;
+    height: 0;
+    border: none;
+    opacity: 0;
+}
+
+#terminal-input-cursor {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+#terminal-input-cursor-padding {
+    opacity: 0;
+}
+
+#terminal-input-cursor-selection {
+    font-weight: bold;
+    animation: blink 1s step-start infinite;
 }
 
 @keyframes blink {
@@ -109,4 +70,14 @@ body {
     100% {
         opacity: 1;
     }
+}
+
+#terminal-input-cursor-selection.block {
+    font-weight: normal;
+    background-color: #f5f5f5;
+    color: #222228;
+}
+
+#input-wrapper input:not(:focus) + label #terminal-input-cursor {
+    /* display: none; */
 }

--- a/public/style.css
+++ b/public/style.css
@@ -34,6 +34,7 @@ body {
 
 #input-wrapper {
     position: relative;
+    white-space: pre-wrap;
 }
 
 #terminal-input {
@@ -79,5 +80,5 @@ body {
 }
 
 #input-wrapper input:not(:focus) + label #terminal-input-cursor {
-    /* display: none; */
+    display: none;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -443,8 +443,40 @@ async function runCommand(
     }
 }
 
+function cullWhitespaceNodes(...ids: string[]) {
+    const targets = [...ids];
+    for (const id of targets) {
+        const element = document.getElementById(id);
+        if (!element) {
+            throw new Error(
+                `unreachable: element with id '${id}' is defined in index.html`,
+            );
+        }
+        for (const node of element.childNodes) {
+            if (node.nodeType !== node.TEXT_NODE) {
+                continue;
+            }
+            const text = node.textContent;
+            if (!text) {
+                throw new Error(
+                    "unreachable: text node always has text content",
+                );
+            }
+            if (text.trim().length !== 0) {
+                continue;
+            }
+            node.remove();
+        }
+    }
+}
+
 async function main() {
     await assertMotdIncludesCmd();
+    cullWhitespaceNodes(
+        "input-wrapper",
+        "user",
+        "terminal-input-label",
+    );
 
     const session = new Session(await root(username), username);
     session.cd(`/home/${username}`);

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -23,7 +23,7 @@ export class Ui {
     private input = document.querySelector<HTMLInputElement>(
         "#terminal-input",
     )!;
-    private userPrefix = document.querySelector<HTMLDivElement>("#user")!;
+    private userPrefix = document.querySelector<HTMLSpanElement>("#user")!;
 
     constructor({ keyListener }: UiConfig) {
         this.input.addEventListener(
@@ -49,9 +49,10 @@ export class Ui {
     private addHistoryItem(output: string) {
         const userPrefixClone = this.userPrefix.cloneNode(
             true,
-        ) as HTMLDivElement;
+        ) as HTMLSpanElement;
 
-        const command = document.createElement("div");
+        const command = document.createElement("span");
+        command.classList.add("user-command");
         command.textContent = this.input.value;
 
         const userAndCommand = document.createElement("div");
@@ -68,7 +69,7 @@ export class Ui {
         historyItem.append(userAndCommand, outputElement);
 
         for (const descendant of historyItem.querySelectorAll("[id]")) {
-            descendant.id = "";
+            descendant.removeAttribute("id");
         }
 
         this.history.appendChild(historyItem);
@@ -101,9 +102,15 @@ export class Ui {
     }
 
     private updateInputAndCursor() {
+        const promptPrefix = document.querySelector("#user")?.textContent;
+        if (!promptPrefix) {
+            throw new Error("unreachable: defined in index.html");
+        }
+
         const termContent = document.querySelector("#terminal-input-content");
         if (!termContent) throw new Error("unreachable: defined in index.html");
-        termContent.textContent = this.input.value;
+        const cursorSpace = " ";
+        termContent.textContent = this.input.value + cursorSpace;
         const cursorPadding = document.querySelector(
             "#terminal-input-cursor-padding",
         );
@@ -114,7 +121,7 @@ export class Ui {
             0,
             this.input.selectionStart ?? this.input.value.length,
         );
-        cursorPadding.textContent = contentUntilSelection;
+        cursorPadding.textContent = promptPrefix + contentUntilSelection;
         const cursorSelection = document.querySelector(
             "#terminal-input-cursor-selection",
         );


### PR DESCRIPTION
## fix text wrapping

### before (cringe)

![image](https://github.com/user-attachments/assets/3c579052-c5e7-46b7-a14f-5a2870b973bb)

### after (based)

![image](https://github.com/user-attachments/assets/925ee857-928f-4980-8c2b-799c0ea33875)

## how did you accomplish such a monumental feat

i removed a bunch of nasty `display: flex` css, and replaced `div`s (which are by default `display: block`) with `span`s (which are by default `display: inline`) where it made sense, allowing the html to function as intended

funny quirks as a result of this:

preface: `position: static` is just the name of the default position if no other position is set

- because stacking static-flowing elements ontop of eachother is apparently a thought crime¹, i had to change the cursor from having its top right position at the end of the user prefix (`guest@mtkonge:~$`) to the start of it, which means i append `guest@mtkonge:~$` to the start of the cursor padding now. otherwise, it will have it's top left point at the end of the user prefix, which makes the cursor act funny on multiple lines
- i had to add an extra ` ` after the input-label's content to allow space for the cursor, otherwise if your cursor is at the end of the text it will overflow and produce a result like
`guest@mtkonge:~$ echo a`
`                       _`
which we don't want
- because we no longer use flex, the standard `pre` whitespace rules apply, and as such html such as
```html
            <span id="user" class="user-prefix">
                <span class="user">guest@mtkonge</span>
                <span>:</span>
                <span id="dir" class="dir">~</span>
                <span>$ </span>
            </span>
```
will literally produce output that looks like
```
            \n
                guest@mtkonge\n
                :</span>\n
                ~</span>\n
                $ \n
            \n
```
the obvious solution would just be to pack it all together:
```html
<span id="user" class="user-prefix"><span class="user">guest@mtkonge</span><span>:</span><span id="dir" class="dir">~</span><span>$ </span></span>
```
but this quickly leads to really ugly and unreadable html. instead, i've made a function that looks for direct-child text nodes of an element, and wipes them if their content solely consists of whitespace. this works like a charm.

## tidbits

1. an inline `position: static` object flows like this
```
           ___________________________
___________| bla bla bla bla bla bla | end of screen
| bla bla bla bla |"""""""""""""""""""
"""""""""""""""""""
```
but if you're using `position: absolute`, `display: flex`, `display: grid`, etc, it flows like this:
```
           ___________________________
           | bla bla bla bla bla bla | end of screen
           | bla bla bla bla bla |""""
           """""""""""""""""""""""
```

which we don't want
so we have to do this instead
```
______________________________________
| .......... bla bla bla bla bla bla | end of screen
| bla bla bla bla |"""""""""""""""""""
"""""""""""""""""""
```
which works like a charm but it'd obviously be preferable if it just worked like you'd want it to in the first place

### css refactor

in addition to this i've refactored the css. i could've refactored it further if i could use modern css features like nesting, or use a css processor to allow modern css features with backwards compatibility for older browsers, but i couldn't get anything to work in a satisfying manner